### PR TITLE
Switched back slash to forward slash in assembly so Merlin32 works on OSX as well as Windows

### DIFF
--- a/src/Master.s
+++ b/src/Master.s
@@ -11,28 +11,28 @@
 
 ; 64KB Tile Memory
 
-            ASM   static\TileData.s
+            ASM   static/TileData.s
             KND   #$1001               ; Type and Attributes ($10=Static,$01=Data)
             ALI   BANK
             SNA   TDATA
 
 ; 64KB Sprite Plane Data
 
-            ASM   static\SprData.s
+            ASM   static/SprData.s
             KND   #$1001               ; Type and Attributes ($11=Static+Bank Relative,$01=Data)
             ALI   BANK
             SNA   SDATA
 
 ; 64KB Sprite Mask Data
 
-            ASM   static\SprMask.s
+            ASM   static/SprMask.s
             KND   #$1001               ; Type and Attributes ($11=Static+Bank Relative,$01=Data)
             ALI   BANK
             SNA   SMASK
 
 ; 64KB Tile Store
 
-            ASM   static\TileStore.s
+            ASM   static/TileStore.s
             KND   #$1001               ; Type and Attributes ($11=Static+Bank Relative,$01=Data)
             ALI   BANK
             SNA   TSTORE


### PR DESCRIPTION
# Summary
Merlin32 on Windows appears to be OK with either forward or backward slash in files. On OSX, it appears to require forward slash in order to assemble the code without error.

This change does assemble without errors on both the `master` branch and `v1.0.0-beta.1` tag. It runs without error on the `v1.0.0-beta.1` tag build. The `master` build has an error when run; but, it appears to be the same error as without the change.

If there are concerns, I am happy to change the target of the PR or hold off on submitting it and retest against `master` in the future based on what works best.

# Test Environment
OSX Catalina (10.15.7) w/ Merlin32 1.1.10
Windows 10 Home (1909) w/ Merlin32 1.1.10